### PR TITLE
Minor README instruction edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add `todo.url = "github:sioodmy/todo";` to your inputs. And `inputs.todo.package
 
 ### other distros
 
-use `cargo build --release` to compile todo and copy `target/release/todo` to `/usr/bin`
+use `cargo build --release` to compile todo and copy `target/release/todo` to `/usr/bin/todo.sh`
 
 ## note
 


### PR DESCRIPTION
On README ("other distros" section), copy binary to `/usr/bin/todo.sh` instead of `/usr/bin`, as the program looks for todo.sh after `cargo build --release`:

```
❯ cp ~/git/todo/target/release/todo /usr/bin/

❯ todo test
zsh: command not found: todo.sh

❯ ls
build            deps             examples         incremental      libtodo_bin.d    libtodo_bin.rlib todo             todo.d

❯ ./todo test
Usage: todo [COMMAND] [ARGUMENTS]
Todo is a super fast and simple tasks organizer written in rust
Example: todo list
Available commands:
    - add [TASK/s]
        adds new task/s
        Example: todo add "buy carrots"
    - edit [INDEX] [EDITED TASK/s]
        edits an existing task/s
        Example: todo edit 1 banana
    - list
        lists all tasks
        Example: todo list
    - done [INDEX]
        marks task as done
        Example: todo done 2 3 (marks second and third tasks as completed)
    - rm [INDEX]
        removes a task
        Example: todo rm 4
    - reset
        deletes all tasks
    - restore 
        restore recent backup after reset
    - sort
        sorts completed and uncompleted tasks
        Example: todo sort
    - raw [todo/done]
        prints nothing but done/incompleted tasks in plain text, useful for scripting
        Example: todo raw done

❯ mv /usr/bin/todo /usr/bin/todo.sh

❯ todo test
Usage: todo [COMMAND] [ARGUMENTS]
Todo is a super fast and simple tasks organizer written in rust
Example: todo list
Available commands:
    - add [TASK/s]
        adds new task/s
        Example: todo add "buy carrots"
    - edit [INDEX] [EDITED TASK/s]
        edits an existing task/s
        Example: todo edit 1 banana
    - list
        lists all tasks
        Example: todo list
    - done [INDEX]
        marks task as done
        Example: todo done 2 3 (marks second and third tasks as completed)
    - rm [INDEX]
        removes a task
        Example: todo rm 4
    - reset
        deletes all tasks
    - restore 
        restore recent backup after reset
    - sort
        sorts completed and uncompleted tasks
        Example: todo sort
    - raw [todo/done]
        prints nothing but done/incompleted tasks in plain text, useful for scripting
        Example: todo raw done

~/git/todo master
❯ 
```