### PR TITLE
feat: support for a --path command line argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,23 @@ use std::env;
 use todo_bin::{help, Todo};
 
 fn main() {
-    let todo = Todo::new().expect("Couldn't create the todo instance");
+    let mut args: Vec<String> = env::args().collect();
+    let mut dir_path: Option<String> = None;
 
-    let args: Vec<String> = env::args().collect();
+    println!("Yayy");
+    println!("{:?}", args);
+    args.retain(|arg| {
+        if let Some(path_str) = arg.strip_prefix("--path=") {
+            dir_path = Some(path_str.to_string());
+            return false;
+        }
+        true
+    });
+    println!("Yayy");
+    println!("{:?}", args);
+    println!("Yayy");
+
+    let todo = Todo::new(dir_path).expect("Couldn't create the todo instance");
 
     if args.len() > 1 {
         let command = &args[1];

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,6 @@ fn main() {
     let mut args: Vec<String> = env::args().collect();
     let mut dir_path: Option<String> = None;
 
-    println!("Yayy");
-    println!("{:?}", args);
     args.retain(|arg| {
         if let Some(path_str) = arg.strip_prefix("--path=") {
             dir_path = Some(path_str.to_string());
@@ -14,9 +12,6 @@ fn main() {
         }
         true
     });
-    println!("Yayy");
-    println!("{:?}", args);
-    println!("Yayy");
 
     let todo = Todo::new(dir_path).expect("Couldn't create the todo instance");
 


### PR DESCRIPTION
--path='/some/path' can now be given to the command to specify the path of the .todo file

this creates support for multiple todo files, although it still restricts the user to have one .todo file per directory

this also unclutters the home directory which is chosen by default